### PR TITLE
Clientprojects

### DIFF
--- a/Developer Education/README.md
+++ b/Developer Education/README.md
@@ -16,7 +16,8 @@ Do the development tasks below when they are referenced in the slides and if you
 
 To practice what you learn from the slides you can do these tasks to create a simple bookstore.
 
-Before you start with the tasks make sure that you have gone through [Litium system requirements](https://docs.litium.com/documentation/get-started/system-requirements).
+Before you start with the tasks make sure that you have gone through [Litium system requirements](https://docs.litium.com/documentation/get-started/system-requirements).<br />
+_(On the system requirements page you'll be asked to install Node.js. Make sure to install version 14.15.0 to be able to work with Litium 8 accelerator client projects)_
 
 Some tasks assume that a previous task has been completed (task dependencies are presented in each tasks README-file), the recommended order to do them are:
 

--- a/Developer Education/Tasks/Installation/README.md
+++ b/Developer Education/Tasks/Installation/README.md
@@ -38,6 +38,12 @@ Check that you have completed the requirements below installed before you start.
     dotnet new litmvcacc
     ```
 
+## Build client projects
+
+1. Navigate to `C:\Temp\LitiumEducation\`.
+1. Run BuildClientProjects.bat as an administrator.   
+(Make sure you have node.js version 14.15.0 installed)
+
 ## Add docker support to the Accelerator
 
 1. Configure Docker
@@ -65,16 +71,16 @@ Check that you have completed the requirements below installed before you start.
                 <PropertyGroup>
                 <!-- Always pull to ensure that the latest image is used -->
                 <DockerfileBuildArguments>--pull</DockerfileBuildArguments>
-                
+
                 <!-- Define the parameters for files and folders to map on the host -->
                 <DockerLitiumFiles>$(MSBuildThisFileDirectory)../files</DockerLitiumFiles>
                 <DockerLitiumLogfile>$(DockerLitiumFiles)/litium.log</DockerLitiumLogfile>
                 <DockerLitiumElasticLogfile>$(DockerLitiumFiles)/elasticsearch.log</DockerLitiumElasticLogfile>
-                
-                <!-- Mappings so that files/logs inside the container is synced with 
+
+                <!-- Mappings so that files/logs inside the container is synced with
                 files/folders foler on host
-                The Docker image used (defined in the Dockerfile) already contains 
-                the environment variable Litium__Folder__Local that defines files to 
+                The Docker image used (defined in the Dockerfile) already contains
+                the environment variable Litium__Folder__Local that defines files to
                 be stored in app_data inside the container -->
                 <DockerfileRunArguments>$(DockerfileRunArguments) -v $(DockerLitiumFiles):/app_data:rw</DockerfileRunArguments>
                 <DockerfileRunArguments>$(DockerfileRunArguments) -v $(DockerLitiumLogfile):/app/bin/$(Configuration)/litium.log:rw</DockerfileRunArguments>
@@ -83,9 +89,9 @@ Check that you have completed the requirements below installed before you start.
                 <!-- Configure the container to use the dnsresolver-container as DNS: -->
                 <DockerfileRunArguments>$(DockerfileRunArguments) --dns 192.168.65.2</DockerfileRunArguments>
                 </PropertyGroup>
-                
-                <!-- Make sure that the files/folders needed exists 
-                (otherwise the automatic volume-mapping will create directories 
+
+                <!-- Make sure that the files/folders needed exists
+                (otherwise the automatic volume-mapping will create directories
                 instead of files) -->
                 <MakeDir Directories="$(DockerLitiumFiles)" Condition="!Exists('$(DockerLitiumFiles)')" />
                 <Touch Files="$(DockerLitiumLogfile)" AlwaysCreate="true" Condition=" !Exists('$(DockerLitiumLogfile)')" />


### PR DESCRIPTION
Hi Mårten!

When setting up an Accelerator project we need to run the BuildClientProjects.bat file with a specific version of Node.js.
This pull request clarifies this and proposes what version to use for Litium Accelerator 8. 

I know this version will change in the future, and will be different for older versions of the Accelerator. 
This is just a suggestion to clarify that the latest version of the Accelerator expects a specific version of Node.js to not get stuck when installing it.